### PR TITLE
BUGFIX: fix compiling of $sce.trustAsHtml value.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# Update
+
+* BUGFIX: ensure element.html() always gets an HTML string if given the result of a $sce method, a TrustedValueHolderType.
+
 # 1.0.1
 
 * Add AngularJS dependency.

--- a/angular-bind-html-compile.js
+++ b/angular-bind-html-compile.js
@@ -10,7 +10,10 @@
                 scope.$watch(function () {
                     return scope.$eval(attrs.bindHtmlCompile);
                 }, function (value) {
-                    element.html(value);
+                    // Incase value is a TrustedValueHolderType, sometimes it
+                    // needs to be explicitly called into a string in order to
+                    // get the HTML string.
+                    element.html(value && value.toString());
                     $compile(element.contents())(scope);
                 });
             }


### PR DESCRIPTION
> Ensure element.html() always gets an HTML string
> if given the result of a $sce method, a
> TrustedValueHolderType.

@incuna/js @perry Please merge, ta!

We have noticed a problem with `$sce.trustAsHtml(someCMSResponseStringOfHtml)` where it returns a `TrustedValueHolderType` – whose `valueOf` method returns an HTML string (identical to `toString`) – and yet when `bind-html-compile` runs `element.html(someCMSResponseStringOfHtml)` it is using the `TrustedValueHolderType` object and not an HTML string, therefore nothing renders.

Simply calling `toString` if possible – truthy values have that method; falsey values are a moot point because there's no difference to `element.html()` if given `0` or `'0'`, or `false` or `'false'` – gets us the HTML string.

I think this is a small change without consequence to current usage of this directive, but I would appreciate a thorough review and discussion about why the problem exists and if, perhaps, there's something else going on. Indeed, in Firefox the bug did not show momentarily (first load of a page), but then proceeded to show just like Safari and Chrome.
